### PR TITLE
Fix asyncResult use!, try..with and try..finally

### DIFF
--- a/src/OrderTaking/Result.fs
+++ b/src/OrderTaking/Result.fs
@@ -430,13 +430,15 @@ module AsyncResultComputationExpression =
             else this.Bind( body(), fun () -> 
                 this.While(guard, body))  
 
-        member this.TryWith(body, handler) =
-            try this.ReturnFrom(body())
-            with e -> handler e
+        member this.TryWith(body, handler) = async {
+            try return! this.ReturnFrom(body())
+            with e -> return! handler e
+        }
 
-        member this.TryFinally(body, compensation) =
-            try this.ReturnFrom(body())
-            finally compensation() 
+        member this.TryFinally(body, compensation) = async {
+            try return! this.ReturnFrom(body())
+            finally compensation()
+        }
 
         member this.Using(disposable:#System.IDisposable, body) =
             let body' = fun () -> body disposable


### PR DESCRIPTION
Hi @swlaschin,

First of all, thanks for the great workshop @ NDC Oslo 2019 :)

We've been messing around with the workshop material with my colleagues and found this issue with `asyncResult`: `use!` immediately disposes the object, before the continuation is actually run. By extension, I checked and found `try..with` to behave in a similar manner.

_I'm not sure if this is the best way to fix it, but it seems to work. The whole custom CE implementation in F# is still somewhat mystic to me._